### PR TITLE
Add a Matrix Validation Utility

### DIFF
--- a/src/main/golem/options.kt
+++ b/src/main/golem/options.kt
@@ -20,3 +20,9 @@ import golem.matrix.*
  *
  */
 var factory: MatrixFactory<Matrix<Double>> = golem.matrix.mtj.MTJMatrixFactory()
+
+/**
+ * Whether to validate the dimensions, symmetry, and values of input matrices. false is faster, and should be
+ * used for realtime applications. true gives you much more useful errors when your matrices are shaped
+ * differently than your code expects. */
+var validateMatrices = true

--- a/src/main/golem/util/validation/README.md
+++ b/src/main/golem/util/validation/README.md
@@ -1,0 +1,105 @@
+# Matrix Validation DSL
+
+This package provides definitions for a domain-specific language that you can use to validate matrices used as inputs to your functions in a consistent way. The rules throw detailed, human-readable exceptions using an appropriate Java exception class based on rules that look like this:
+
+```kotlin
+import golem.*
+import golem.util.validation.*
+
+fun mFunction(foo: Matrix<Double>, bar: Matrix<Double>, baz: Matrix<Double>) {
+    validate {
+        foo("foo") {  1  x 'N'; transposable }
+        bar("bar") { 'N' x 'N'; symmetric }
+        baz("baz") { 'N' x  1 ; max = 5 }
+    }
+
+    /* Your code here */
+}
+```
+
+Some of the exceptions the above code could generate include:
+
+```
+java.lang.IndexOutOfBoundsException: Invalid matrix dimensions.
+
+Matrix Required Actual 
+====== ======== ====== 
+foo       1xN     1x2  
+bar       NxN     2x2  
+baz       Nx1     2x3  
+
+baz must have the same number of rows as foo has columns
+baz must have the same number of rows as bar has rows
+baz must have the same number of rows as bar has columns
+baz must have exactly 1 columns (has 3)
+```
+
+or
+
+```
+java.lang.IndexOutOfBoundsException: bar must be symmetric, but has dimensions 1x2
+```
+
+or
+
+```
+java.lang.IllegalArgumentException: baz[0, 0] > 5.0 (value was 15.0)
+```
+
+## Annotated Syntax
+```kotlin
+fun myFunction(foo: Matrix<Double>, bar: Matrix<Double>, baz: Matrix<Double>) {
+    validate { /*
+        vvv ------------------------------------ Matrix to examine.
+            vvvvv ------------------------------ Name to use in the exception.
+                    vvvvvvvvvvvvvvvvvvvvvvvv --- Rules to check the matrix */
+        foo("foo") { 1  x 'N'; transposable }
+    }
+}
+```
+
+## Rules
+Rules are regular Kotlin statements, which can be separated either by semicolons or newlines. The rules block will be evaluated with an instance of `ValidaitonContext` as its receiver.
+
+|      Syntax            |     Description                                          |
+|------------------------|----------------------------------------------------------|
+| `1 x 2` or `dim(1, 2)` | Verify the matrix has 1 row and 2 columns. Values can be any expression that evaluates to `Int`. The latter syntax is provided as an alternative if the order-of-operations for [infix functions](https://kotlinlang.org/docs/reference/functions.html#infix-notation) does something weird.  |
+| `1 x 'N'`              | Verify the matrix has 1 row and any number of columns; compare the column count to other things that use the character `'N'`|
+| `transposable`         | The given dimensions can be in either order. So, a `1 x 3; transposable` matrix can have either 1 row and 3 columns or 3 rows and 1 column. |
+| `symmetric`            | Verify that the matrix is [symmetric](http://mathworld.wolfram.com/SymmetricMatrix.html) |
+| `max = 4.0`            | Specify a maximum allowable value for individual coefficients in the matrix. Can be any expression that evaluates to `Double` |
+| `min = 2.0`            | Specify a minimum allowable value for individual coefficients in the matrix. Can be any expression that evaluates to `Double` |
+
+
+## Shorthand for a single Matrix
+If you've written a function that only has a single Matrix argument, you can use this shorthand syntax instead of a full validate block.
+
+```kotlin
+fun myFunction(foo: Matrix<Double>) {
+    foo.validate("foo") { 1 x 3; transposable }
+
+    /* Your code here */
+}
+```
+
+### A Cautionary Example
+If you have more than one matrix, you should avoid the shorthand syntax because dimensions variables will not "stick" as you might expect. For example:
+
+```kotlin
+fun myFunction(foo: Matrix<Double>, bar: Matrix<Double>) {
+    foo.validate("foo") {  1  x 'N'; transposable }
+    bar.validate("bar") { 'N' x 'N' } // <-- WILL NOT WORK
+    
+
+    /* Your code here */
+}
+```
+
+In that example, it will validate that `bar` is square, but not that its dimensions correspond with the number of columns in `foo` as you might expect. This is because each validate block allocates a separate `ValidationContext` that performs some of its validations at the end of the block.
+
+## How it works
+Behind the scenes, the validation code uses kotlin [extension methods](http://kotlinlang.org/docs/reference/extensions.html) to enable a syntax inspired by Kotlin's ["Type-safe builders" feature](http://kotlinlang.org/docs/reference/type-safe-builders.html).
+
+Each of the validation rules you define is calling an extension method on the `ValidationContext` class.
+
+If you'd like to extend the validation syntax yourself, you can do so by adding more extension methods to `ValidationContext`. `bounds.kt` probably offers the best example to work from.

--- a/src/main/golem/util/validation/bounds.kt
+++ b/src/main/golem/util/validation/bounds.kt
@@ -1,0 +1,49 @@
+@file:JvmName("BoundsValidation")
+
+package golem.util.validation
+import golem.validateMatrices
+import golem.*
+
+/**
+ * Maximum value for individual elements in the matrix.
+ */
+var ValidationContext.max : Double
+    get() { throw UnsupportedOperationException() }
+    set(value) { max(value) }
+
+/**
+ * Ensure all of the elements in the current matrix are >= the given value.
+ * @param value The maximum value required of all elements in the matrix.
+ */
+fun ValidationContext.max(value: Double) : ValidationContext {
+    if (!validateMatrices) return this
+    currentMatrix.eachIndexed { row, col, element ->
+        if (element > value) {
+            val msg = "${currentMatrixName}[${row}, ${col}] > ${value} (value was ${element})"
+            throw IllegalArgumentException(msg)
+        }
+    }
+    return this
+}
+
+/**
+ * Minimum value for individual elements in the matrix.
+ */
+var ValidationContext.min : Double
+    get() { throw UnsupportedOperationException() }
+    set(value) { min(value) }
+
+/**
+ * Ensure all of the elements in the current matrix are >= the given value.
+ * @param value The minimum value required of all elements in the matrix.
+ */
+fun ValidationContext.min(value: Double) : ValidationContext {
+    if (!validateMatrices) return this
+    currentMatrix.eachIndexed { row, col, element ->
+        if (element < value) {
+            val msg = "${currentMatrixName}[${row}, ${col}] < ${value} (value was ${element})"
+            throw IllegalArgumentException(msg)
+        }
+    }
+    return this
+}

--- a/src/main/golem/util/validation/common.kt
+++ b/src/main/golem/util/validation/common.kt
@@ -1,0 +1,182 @@
+@file:JvmName("Validation")
+
+package golem.util.validation
+
+import golem.validateMatrices
+import golem.matrix.Matrix
+import kotlin.collections.Iterable
+import kotlin.collections.MutableList
+import kotlin.collections.MutableMap
+import kotlin.collections.MutableSet
+import java.util.LinkedHashMap
+import java.util.ArrayList
+import java.util.HashSet
+
+
+private val DEFAULT_NAME = "matrix"
+
+/**
+ * Callback used by ValidationContext after evaluating all rules. Subclass this if your validation plugin needs
+ * to hold all validation until the end.
+ */
+interface Validator {
+    /**
+     * Validate all the matrices in the context according to your collected rules.
+     */
+    fun performValidation(context: ValidationContext)
+}
+
+
+/**
+ * A lambda receiver with state and convenience methods for validating a group of matrices.
+ *
+ * In general there is no reason to instantiate this directly, instead @see validate(fn) for example usage.
+ */
+class ValidationContext {
+    val matrices = mutableListOf<Matrix<Double>>()
+    val matrixNames = mutableListOf<String>()
+    val metadataStorage = mutableMapOf<String, Any>()
+    private val validators = mutableSetOf<Validator>()
+
+    val currentMatrix: Matrix<Double> get() = matrices[matrices.size - 1]
+    val currentMatrixName: String get() = matrixNames[matrixNames.size - 1]
+
+    /**
+     * Execute the given fn (which should contain validation rules) against the given matrix.
+     *
+     * In general it is preferable to use the other verison of this function that lets you specify a name.
+     * All matrices that are validated with this method will appear in the error message with the name
+     * "matrix"
+     *
+     */
+    operator fun Matrix<Double>.invoke(fn: ValidationContext.() -> Unit): ValidationContext = this(DEFAULT_NAME, fn)
+
+    /**
+     * Execute the given fn (which should contain validation rules) against the given matrix with the given
+     * name.
+     * @param name Name of the matrix to report in validation error messages.
+     * @returns this
+     */
+    operator fun Matrix<Double>.invoke(name: String, fn: ValidationContext.() -> Unit): ValidationContext {
+        matrixNames.add(name)
+        matrices.add(this)
+        if (validateMatrices)
+            fn(this@ValidationContext)
+        return this@ValidationContext
+    }
+
+    // Convenience methods for dimension checking
+    //@formatter: off
+    /** @see dim( Int,  Int) */ infix fun  Int.x(cols: Int)  { dim(this, cols) }
+    /** @see dim( Int, Char) */ infix fun  Int.x(cols: Char) { dim(this, cols) }
+    /** @see dim(Char,  Int) */ infix fun Char.x(cols: Int)  { dim(this, cols) }
+    /** @see dim(Char, Char) */ infix fun Char.x(cols: Char) { dim(this, cols) }
+    //@formatter: on
+
+    /**
+     * Add a helper that will perform validation at the end of the block.
+     */
+    fun addValidator(validator: Validator) {
+        validators.add(validator)
+    }
+
+    /**
+     * Check declared matrices against any rules that have been added with addValidator.
+     */
+    fun validate() {
+        if (!validateMatrices) return
+        for (validator in validators)
+            validator.performValidation(this)
+    }
+
+    inline fun <reified T> metadata(key: String, factory: () -> T): T {
+        return metadataStorage.getOrPut(key, { factory() as Any }) as T
+    }
+
+    // Method syntax workaround for people who use testMatrix instead of validate.
+    operator fun invoke() : ValidationContext = this
+}
+
+
+/**
+ * Return a validation context that can be used to validate the given matrix with the default name of "matrix".
+ *
+ * In general it is preferable to use the other verison of this function that lets you specify a name. All
+ * matrices that are validated with this method will appear in the error message with the name "matrix"
+ *
+ * @param matrix A matrix to validate.
+ * @returns A validation context that can be used to validate the given matrix.
+ */
+fun testMatrix(matrix: Matrix<Double>) : ValidationContext = testMatrix(matrix, DEFAULT_NAME)
+
+/**
+ * Return a validation context that can be used to validate the given matrix with the given name.
+ *
+ * <pre>
+ * {@code
+ * testMatrix(myMatrix, "myMatrix").dim(1, 4).validate() // validates myMatrix is 1 by 4.
+ * }
+ * </pre>
+ *
+ * @param matrix A matrix to validate.
+ * @param name The name of the matrix (used in displayed errors)
+ * @returns A validation context that can be used to validate the given matrix.
+ */
+fun testMatrix(matrix: Matrix<Double>, name: String) : ValidationContext  {
+    val ctx = ValidationContext()
+    ctx.matrixNames.add(name)
+    ctx.matrices.add(matrix)
+    return ctx
+}
+
+/**
+ * Execute the given rules within a ValidationContext, letting you validate multiple matrices at once with
+ * interrelated dimensions, and return a list of matrices that match your validation rules.
+ *
+ * <pre>
+ * {@code
+ * val (myFoo, myBar) = validate {
+ *     foo("foo") { 1 x 'N' }
+ *     bar("bar") { 'N' x 1; max = 0.5 }
+ * }
+ * }
+ * </pre>
+ */
+fun validate(fn: ValidationContext.() -> Unit) {
+    val ctx = ValidationContext()
+    ctx.fn()
+    ctx.validate()
+}
+
+/**
+ * Use the given fn to validate a matrix. Return either the matrix itself or a copy that has been transformed
+ * to match the validation rules.
+ *
+ * In general it is preferable to use the other verison of this function that lets you specify a name. All
+ * matrices that are validated with this method will appear in the error message with the name "matrix"
+ *
+ * @see Matrix<Double>.validate(name, fn)
+ * @param fn Validation rules for the matrix.
+ * @returns Either a reference to the input matrix itself, or a transformed version. The return value is
+ * guaranteed to pass the validation rules.
+ */
+fun Matrix<Double>.validate(fn: ValidationContext.() -> Unit) = validate(DEFAULT_NAME, fn)
+
+
+/**
+ * Use the given fn to validate a matrix with the given name. Return either the matrix itself or a copy that
+ * has been transformed to match the validation rules.
+ *
+ * <pre>
+ * {@code
+ * myMatrix.validate("myMatrix") { 1 x 4 } // validates myMatrix is 1 by 4.
+ * }
+ * </pre>
+ *
+ * @param name The name of the matrix (used in displayed errors)
+ * @param fn Validation rules for the matrix.
+ */
+fun Matrix<Double>.validate(name: String, fn: ValidationContext.() -> Unit) {
+    val matrix = this
+    golem.util.validation.validate { matrix(name, fn) }
+}

--- a/src/main/golem/util/validation/dimensions.kt
+++ b/src/main/golem/util/validation/dimensions.kt
@@ -1,0 +1,255 @@
+@file:JvmName("DimensionValidation")
+
+package golem.util.validation
+import golem.validateMatrices
+import golem.matrix.Matrix
+import kotlin.collections.MutableMap
+import kotlin.collections.mutableMapOf
+import kotlin.collections.MutableSet
+import kotlin.collections.mutableSetOf
+import java.util.HashSet
+
+private val ValidationContext.meta : DimensionValidator get() {
+    return this.metadata("dim") {
+        val instance = DimensionValidator()
+        addValidator(instance)
+        instance
+    }
+}
+
+private class DimensionValidator: Validator {
+    // For named variables, the possible values they might take based on scanned matrix dimensions.
+    private val possibleValues = mutableMapOf<Char, MutableSet<Int>>()
+    // Possible valid dimensions for a given matrix
+    private val dimensions = mutableMapOf<Matrix<Double>, Pair<MutableSet<Int>, MutableSet<Int>>>()
+    // The declared dimensions for the matrix with the given name. Strings in the pair will either be
+    // numeric or a single character.
+    private val declared = mutableMapOf<String, Pair<String, String>>()
+    // Matrix names we've already complained about while building our error string.
+    private val seenInError = mutableSetOf<String>()
+    // Matrices that have been declared transposable.
+    private val transposable = mutableSetOf<Matrix<Double>>()
+
+    private fun inferValues(letter: Char, vararg dimensions: Int) : MutableSet<Int> {
+        val possible = possibleValues.getOrPut(letter) { dimensions.toMutableSet() }
+        possible.retainAll(dimensions.asIterable())
+        return possible
+    }
+
+    fun dim(name: String, matrix: Matrix<Double>, rows: Int, cols: Int) {
+        declared[name] = Pair("$rows", "$cols")
+        dimensions[matrix] = Pair(mutableSetOf(rows), mutableSetOf(cols))
+    }
+
+    fun dim(name: String, matrix: Matrix<Double>, rows: Int, cols: Char) {
+        declared[name] = Pair("$rows", "$cols")
+        val inferenceSource = if (matrix.numCols() == rows) {
+            matrix.numRows()
+        } else {
+            matrix.numCols()
+        }
+        dimensions[matrix] = Pair(mutableSetOf(rows), inferValues(cols, inferenceSource))
+    }
+
+    fun dim(name: String, matrix: Matrix<Double>, rows: Char, cols: Int) {
+        declared[name] = Pair("$rows", "$cols")
+        val inferenceSource = if (matrix.numRows() == cols) {
+            matrix.numCols()
+        } else {
+            matrix.numRows()
+        }
+        dimensions[matrix] = Pair(inferValues(rows, inferenceSource), mutableSetOf(cols))
+    }
+
+    fun dim(name: String, matrix: Matrix<Double>, rows: Char, cols: Char) {
+        declared[name] = Pair("$rows", "$cols")
+        dimensions[matrix] = Pair(inferValues(rows, matrix.numRows(), matrix.numCols()),
+                                  inferValues(cols, matrix.numRows(), matrix.numCols()))
+    }
+
+    fun markTransposable(matrix: Matrix<Double>) {
+        transposable.add(matrix)
+    }
+
+    override fun performValidation(context: ValidationContext) {
+        val failed = mutableListOf<Pair<String, Matrix<Double>>>()
+        for ((index, matrix) in context.matrices.withIndex()) {
+            dimensions[matrix]?.let { matrixDimension ->
+                val (expectedRows, expectedCols) = matrixDimension
+                val actualRows = matrix.numRows()
+                val actualCols = matrix.numCols()
+                if (actualRows in expectedRows && actualCols in expectedCols) {
+                    expectedRows.retainAll(arrayOf(actualRows))
+                    expectedCols.retainAll(arrayOf(actualCols))
+                } else if (actualRows in expectedCols
+                        && actualCols in expectedRows
+                        && matrix in transposable) {
+                    expectedCols.retainAll(arrayOf(actualRows))
+                    expectedRows.retainAll(arrayOf(actualCols))
+                } else {
+                    failed.add(Pair(context.matrixNames[index], matrix))
+                }
+            }
+        }
+        if (failed.size > 0) {
+            throw IndexOutOfBoundsException(concoctExceptionMessage(context, failed))
+        }
+    }
+
+
+    // Append text to the StringBuilder, padded out to the given width with the given characters.
+    private fun StringBuilder.writeColumn(width: Int, text: String, lpad: Char? = null, rpad: Char? = ' ',
+                                        gap: Char? = ' ') {
+        val nrpad = if (rpad == null) 0 else (width - text.length) / (if (lpad == null) 1 else 2)
+        val nlpad = if (lpad == null) 0 else (width - nrpad - text.length)
+        if (lpad != null)
+            for (x in 1..nlpad)
+                append(lpad)
+        append(text)
+        if (rpad != null)
+            for (x in 1..nrpad)
+                append(rpad)
+        if (gap != null)
+            append(gap)
+    }
+
+    // Build an english-description of numeric dimensions
+    private fun concoctFixedDescription(rows: String, cols: String): String {
+        if (rows == "1")
+            return "a ${cols}-vector"
+        if (cols == "1")
+            return "a ${rows}-vector"
+        return "$rows by $cols"
+    }
+
+    // Build a list of things compareTo needs to be the same as. Looks up other things that have
+    // the same character-based dimension defined.
+    private fun concoctComparison(name: String, compareTo: String): List<String> {
+        val out = mutableListOf<String>()
+        if (compareTo !in seenInError) {
+            for ((name2, dims) in declared) {
+                val (rows, cols) = dims
+                if (name2 != name) {
+                    if (rows == compareTo) out.add("as $name2 has rows")
+                    if (cols == compareTo) out.add("as $name2 has columns")
+                }
+            }
+            seenInError.add(compareTo)
+        }
+        return out
+    }
+
+    // Build our pretty table of dimensions real vs actual.
+    private fun concoctExceptionMessage(context: ValidationContext, failed: List<Pair<String,
+    Matrix<Double>>>): String {
+        val strings = mutableListOf<String>()
+        for ((index, matrix) in context.matrices.withIndex()) {
+            val name = context.matrixNames[index]
+            declared[name]?.let { decl ->
+                strings.add(name)
+                val (r, c) = decl
+                strings.add("${r}x${c}")
+                strings.add("${matrix.numRows()}x${matrix.numCols()}")
+            }
+        }
+        val headers = arrayOf("Matrix", "Required", "Actual")
+        val widths = mutableListOf(headers[0].length, headers[1].length, headers[2].length)
+        for ((index, str) in strings.withIndex())
+            if (str.length > widths[index % widths.size])
+                widths[index % widths.size] = str.length
+        return buildString {
+            append("Invalid matrix dimensions.\n\n")
+            for ((index, header) in headers.withIndex())
+                writeColumn(widths[index], header, ' ', ' ')
+            append("\n")
+            for (width in widths)
+                writeColumn(width, "", '=', null)
+            for ((index, str) in strings.withIndex()) {
+                val windex = index % widths.size
+                if (windex == 0) append("\n")
+                writeColumn(widths[windex], str, if (windex == 0) null else ' ')
+            }
+            append("\n")
+            for ((name, matrix) in failed) {
+                declared[name]?.let { decl ->
+                    val (rows, cols) = decl
+                    if (rows.matches(Regex("^\\d+$")) && cols.matches(Regex("^\\d+$"))) {
+                        append("\n$name must be ${concoctFixedDescription(rows, cols)}, got ")
+                        append(concoctFixedDescription("${matrix.numRows()}",
+                                                       "${matrix.numCols()}"))
+                        // do nothing
+                    }
+                    if (rows.matches(Regex("^\\d+$"))) {
+                        append("\n$name must have exactly $rows rows (has ${matrix.numRows()})")
+                    } else {
+                        for (comparison in concoctComparison(name, rows))
+                            append("\n$name must have the same number of rows $comparison")
+                    }
+                    if (cols.matches(Regex("^\\d+$"))) {
+                        append("\n$name must have exactly $cols columns (has ${matrix.numCols()})")
+                    } else {
+                        for (comparison in concoctComparison(name, rows))
+                            append("\n$name must have the same number of columns $comparison")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Require the current matrix to have exactly the given number of rows and columns.
+ * @param rows Fixed number of rows to require.
+ * @param cols Fixed number of columns to require.
+ */
+fun ValidationContext.dim(rows: Int,  cols:  Int) : ValidationContext {
+    if (validateMatrices)
+        meta.dim(currentMatrixName, currentMatrix, rows, cols)
+    return this
+}
+
+/**
+ * Require the current matrix to have exactly the given number of rows and match the number of columns with
+ * other dimensions in other matrices based on the cols variable name.
+ * @param rows Fixed number of rows to require.
+ * @param cols Variable name for the number of cols in the matrix
+ */
+fun ValidationContext.dim(rows: Int,  cols: Char) : ValidationContext {
+    if (validateMatrices)
+        meta.dim(currentMatrixName, currentMatrix, rows, cols)
+    return this
+}
+
+/**
+ * Require the current matrix to have exactly the given number of columns and match the number of rows with
+ * other dimensions in other matrices based on the rows variable name.
+ * @param rows Variable name for the number of rows in the matrix
+ * @param cols Fixed number of columns to require.
+ */
+fun ValidationContext.dim(rows: Char, cols:  Int) : ValidationContext {
+    if (validateMatrices)
+        meta.dim(currentMatrixName, currentMatrix, rows, cols)
+    return this
+}
+
+/**
+ * Require the current matrix's dimensions to correspond to the given variable names. Compares with other
+ * dimensions in other matrices in the context that are assigned the same variable name and raises an error if
+ * they don't all match.
+ * @param rows Variable name for the number of rows in the matrix
+ * @param cols Variable name for the number of cols in the matrix
+ */
+fun ValidationContext.dim(rows: Char, cols: Char) : ValidationContext {
+    if (validateMatrices)
+        meta.dim(currentMatrixName, currentMatrix, rows, cols)
+    return this
+}
+
+/**
+ * Accept a transposed version of the matrix as satisfying the dimensions check. For example, allow a 1 x 3
+ * matrix when dimensions are declared as 3 x 1.
+ */
+val ValidationContext.transposable : ValidationContext get() {
+    meta.markTransposable(currentMatrix)
+    return this
+}

--- a/src/main/golem/util/validation/symmetry.kt
+++ b/src/main/golem/util/validation/symmetry.kt
@@ -1,0 +1,26 @@
+@file:JvmName("SymmetryValidation")
+
+package golem.util.validation
+import golem.validateMatrices
+
+
+/**
+ * Require the current matrix to be symmetric.
+ */
+val ValidationContext.symmetric: ValidationContext get() {
+    if (!validateMatrices) return this
+    val rows = currentMatrix.numRows()
+    val cols = currentMatrix.numCols()
+    if (rows != cols) {
+        val msg = "${currentMatrixName} must be symmetric, but has dimensions ${rows}x${cols}"
+        throw IndexOutOfBoundsException(msg)
+    }
+    for (row in 0.until(rows))
+        for (col in row.until(cols))
+            if (currentMatrix[row, col] != currentMatrix[col, row]) {
+                val msg = "${currentMatrixName} must be symmetric, but " +
+                    "${currentMatrixName}[${row}, ${col}] != ${currentMatrixName}[${col}, ${row}]."
+                throw IllegalArgumentException(msg)
+            }
+    return this
+}

--- a/src/test/golem/ValidationTests.kt
+++ b/src/test/golem/ValidationTests.kt
@@ -1,0 +1,245 @@
+package golem
+
+import golem.*
+import golem.matrix.*
+import golem.util.test.*
+import golem.util.validation.*
+import org.junit.Test
+import org.junit.Rule
+import org.junit.rules.ExpectedException
+
+//@formatter: off
+class ValidationTests {
+    // Visual tests are tests which fail on purpose so you can examine the output.  In this file, the visual tests show
+    // you the exception messages so you can check that they're human-readable and formatted nicely.
+    public val visualTestsOn = false
+
+    @Rule
+    @JvmField
+    public val exception = ExpectedException.none()
+
+    @Test
+    fun test_simpleBoundsChcek() {
+        val foo = mat[1, 2, 3]
+        exception.expect(IndexOutOfBoundsException::class.java)
+        foo.validate { 2 x 2 }
+    }
+
+    @Test
+    fun test_letterBoundsCheck() {
+        val foo = mat[1, 2, 3]
+        val bar = mat[1, 2, 3, 4]
+        exception.expect(IndexOutOfBoundsException::class.java)
+        validate {
+            foo { 1 x 'N' }
+            bar { 1 x 'N' }
+        }
+    }
+
+    @Test
+    fun test_nonIdiomaticFormChainable() {
+        val foo = mat[ 1, 2 end
+                       3, 4 ]
+        val bar = mat[ 1, 2 end
+                       2, 1 ]
+        testMatrix(bar).dim(2, 2).symmetric().min(0.0).max(5.0).validate()
+        exception.expect(IllegalArgumentException::class.java)
+        testMatrix(foo).dim(2, 2).symmetric().min(0.0).max(5.0).validate()
+    }
+
+    @Test
+    fun test_boundsCheckOverloadsExist() {
+        mat[1, 2, 3].validate {  1  x  3  }
+        mat[1, 2, 3].validate {  1  x 'M' }
+        mat[1, 2, 3].validate { 'N' x  3  }
+        mat[1, 2, 3].validate { 'N' x 'M' }
+    }
+
+    @Test
+    fun test_boundsFiguresOutHowToOrientData() {
+        val a = mat[-1,  -2, -3]
+        val b = mat[ 1,  2,  3 end
+                     4,  5,  6 end
+                     7,  8,  9 end
+                    10, 11, 12]
+        val c = mat[-4, -5, -6, -7]
+        validate {
+            a {  1  x 'N'; transposable }
+            b { 'N' x 'M'; transposable }
+            c { 'M' x  1 ; transposable }
+        }
+    }
+
+    @Test
+    fun test_min() {
+        exception.expect(IllegalArgumentException::class.java)
+        mat[1, 2, 3].validate { min = 4.0 }
+    }
+
+    @Test
+    fun test_max() {
+        exception.expect(IllegalArgumentException::class.java)
+        mat[1, 2, 3].validate { max = 0.0 }
+    }
+
+    @Test
+    fun test_symmetric() {
+        val sym = mat[ 1, 2, 3 end
+                       2, 4, 5 end
+                       3, 5, 6]
+        val asym = mat[1, 2, 3 end
+                       4, 5, 6 end
+                       7, 8, 9]
+        sym.validate { symmetric }
+        exception.expect(IllegalArgumentException::class.java)
+        asym.validate { symmetric }
+    }
+
+    @Test
+    fun test_symmetricWithImpossibleDimensions() {
+        val asym = mat[1, 2, 3]
+        exception.expect(IndexOutOfBoundsException::class.java)
+        asym.validate { symmetric }
+    }
+
+    @Test
+    fun test_symmetricAndBoundsInSameExpr() {
+        val sym = mat[1, 2 end 2, 1]
+        sym.validate { symmetric; 2 x 2}
+    }
+
+
+    @Test
+    fun test_namesInExceptionsDimInline() {
+        exception.expectMessage("foo")
+        mat[1, 2, 3].validate("foo") { 2 x 2 }
+    }
+
+    @Test
+    fun test_namesInExceptionsDimMaxBlock() {
+        exception.expectMessage("bar")
+        validate {
+            mat[1, 2, 3]("bar") { 2 x 2 }
+        }
+    }
+
+    @Test
+    fun test_nameInExceptionsDimTestMatrix() {
+        exception.expectMessage("baz")
+        testMatrix(mat[1, 2, 3], "baz").dim(2, 2).validate()
+    }
+
+    @Test
+    fun test_namesInExceptionsMaxInline() {
+        exception.expectMessage("foo")
+        mat[1, 2, 3].validate("foo") { max = 2.0 }
+    }
+
+    @Test
+    fun test_namesInExceptionsMaxBlock() {
+        exception.expectMessage("bar")
+        validate {
+            mat[1, 2, 3]("bar") { max = 2.0 }
+        }
+    }
+
+    @Test
+    fun test_nameInExceptionsMaxTestMatrix() {
+        exception.expectMessage("baz")
+        testMatrix(mat[1, 2, 3], "baz").max(2.0).validate()
+    }
+
+    @Test
+    fun test_namesInExceptionsMinInline() {
+        exception.expectMessage("foo")
+        mat[1, 2, 3].validate("foo") { min = 2.0 }
+    }
+
+    @Test
+    fun test_namesInExceptionsMinBlock() {
+        exception.expectMessage("bar")
+        validate {
+            mat[1, 2, 3]("bar") { min = 2.0 }
+        }
+    }
+
+    @Test
+    fun test_nameInExceptionsMinTestMatrix() {
+        exception.expectMessage("baz")
+        testMatrix(mat[1, 2, 3], "baz").min(2.0).validate()
+    }
+
+    @Test
+    fun test_namesInExceptionsSymmetricInline() {
+        exception.expectMessage("foo")
+        mat[1, 2, 3].validate("foo") { symmetric }
+    }
+
+    @Test
+    fun test_namesInExceptionsSymmetricMaxBlock() {
+        exception.expectMessage("bar")
+        validate {
+            mat[1, 2, 3]("bar") { symmetric }
+        }
+    }
+
+    @Test
+    fun test_nameInExceptionsSymmetricTestMatrix() {
+        exception.expectMessage("baz")
+        testMatrix(mat[1, 2, 3], "baz").symmetric.validate()
+    }
+
+
+
+    @Test
+    fun test_visual_maxExceptionMessage() {
+        if (!visualTestsOn) return
+        mat[15,7].validate("CaridinaCantonensis") { max = 5.0 }
+    }
+
+    @Test
+    fun test_visual_minExceptionMessage() {
+        if (!visualTestsOn) return
+        mat[15,7].validate("NeocaridinaZhanghjiajiensis") { min = 10.0 }
+    }
+
+    @Test
+    fun test_visual_dimensionsExceptionMessage() {
+        if (!visualTestsOn) return
+        validate {
+            mat[1, 2, 3]("first")        {  1  x  2  }
+            mat[2, 3 end 4, 5]("second") { 'M' x 15  }
+            mat[1]("third")              { 'N' x 'M' }
+            mat[1 end 2]("This is a really long name, isn't it?") { 'M' x 'N' }
+        }
+    }
+
+    @Test
+    fun test_visual_symmetricExceptionMessage() {
+        if (!visualTestsOn) return
+        mat[1, 2 end 3, 4].validate("PenaeusMonodon") { symmetric }
+    }
+
+    @Test
+    fun test_visual_symmetricImpossibleBoundsExceptionMessage() {
+        if (!visualTestsOn) return
+        mat[1, 2].validate("MacrobrachiumCarcinus") { symmetric }
+    }
+
+    fun doSomething(foo: Matrix<Double>, bar: Matrix<Double>, baz: Matrix<Double>) {
+        validate {
+            foo("foo") { 1 x 'N'; max = 2*PI; min = -2*PI }
+            bar("bar") { 'N' x 'N'; symmetric }
+            baz("baz") { 'N' x 1; }
+        }
+    }
+
+    @Test
+    fun test_visual_exampleInHipchat() {
+        if (!visualTestsOn) return
+        doSomething(mat[1, 2], mat[1, 2 end 2, 1], mat[1, 2, 3 end 4, 5, 6])
+    }
+}
+
+
+


### PR DESCRIPTION
Because there is no way to validate matrices at compile time, functions which take a `Matrix<Double>` as their parameter must inspect the dimensions, symmetry, and bounds of that matrix and throw a runtime exception if the given matrix is not valid for the context. This pull request provides a reusable validation DSL that generate detailed, consistent exceptions for matrix parameters in function calls. The functionality is documented in [the accompanying README](https://github.com/drmoose/golem/tree/validation/src/main/golem/util/validation).