### PR TITLE
Document meaning of TimeStandard values.

### DIFF
--- a/src/main/golem/containers/TimeStandard.kt
+++ b/src/main/golem/containers/TimeStandard.kt
@@ -5,12 +5,18 @@ package golem.containers
  */
 class TimeStandard(val value: String) {
     companion object {
+        /** Seconds since the GPS epoch, 6 Jan 1980 */
         @JvmField
         val GPS = TimeStandard("GPS")
+
+        /** Value of some local clock; not necessarily synced to any external reference. */
         @JvmField
         val WALL = TimeStandard("WALL")
+
+        /** Seconds since the UNIX epoch, 1 Jan 1970 */
         @JvmField
         val UNIX = TimeStandard("UNIX")
+
         @JvmField
         val OTHER = TimeStandard("OTHER")
     }


### PR DESCRIPTION
This MR adds docstrings describing the various values of TimeStandard, mostly because it is nigh impossible to figure out what `WALL` is supposed to mean by web searches alone.