### PR TITLE
Add toString functions to Time and TimeStandard.

### DIFF
--- a/golem-core/src/golem/containers/Time.kt
+++ b/golem-core/src/golem/containers/Time.kt
@@ -20,6 +20,6 @@ data class Time @JvmOverloads constructor(var time: Double, var timeStandard: Ti
     }
 
     /** Return a human-readable representation of this Time */
-    override fun toString() : String = String.format("%s:%.1f", timeStandard.toString(), time)
+    override fun toString() : String = String.format("%s:%.3f", timeStandard.toString(), time)
 }
 

--- a/golem-core/src/golem/containers/Time.kt
+++ b/golem-core/src/golem/containers/Time.kt
@@ -18,5 +18,8 @@ data class Time @JvmOverloads constructor(var time: Double, var timeStandard: Ti
             throw Exception("TimeStandard ${this.timeStandard.value} does not match" +
                     " ${other.timeStandard.value}")
     }
+
+    /** Return a human-readable representation of this Time */
+    override fun toString() : String = String.format("%s:%.1f", timeStandard.toString(), time)
 }
 

--- a/golem-core/src/golem/containers/TimeStandard.kt
+++ b/golem-core/src/golem/containers/TimeStandard.kt
@@ -20,5 +20,8 @@ class TimeStandard(val value: String) {
         @JvmField
         val OTHER = TimeStandard("OTHER")
     }
+
+    /** Return a human-readable representation of this TimeStandard */
+    override fun toString() : String = value
 }
 

--- a/golem-tests/test/golem/ContainersTests.kt
+++ b/golem-tests/test/golem/ContainersTests.kt
@@ -36,9 +36,9 @@ class ContainersTests {
 
     @Test
     fun testToString() {
-        assertEquals("GPS:0.0", t1.toString())
-        assertEquals("GPS:1.0", t2.toString())
-        assertEquals("WALL:1.0", t3.toString())
-        assertEquals("OTHER:1.0", t4.toString())
+        assertEquals("GPS:0.000", t1.toString())
+        assertEquals("GPS:1.000", t2.toString())
+        assertEquals("WALL:1.000", t3.toString())
+        assertEquals("OTHER:1.000", t4.toString())
     }
 }

--- a/golem-tests/test/golem/ContainersTests.kt
+++ b/golem-tests/test/golem/ContainersTests.kt
@@ -3,6 +3,7 @@ package golem
 import golem.containers.Time
 import golem.containers.TimeStandard
 import org.junit.Test
+import org.junit.Assert.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
@@ -33,4 +34,11 @@ class ContainersTests {
         t4.checkStandard(t1)
     }
 
+    @Test
+    fun testToString() {
+        assertEquals("GPS:0.0", t1.toString())
+        assertEquals("GPS:1.0", t2.toString())
+        assertEquals("WALL:1.0", t3.toString())
+        assertEquals("OTHER:1.0", t4.toString())
+    }
 }


### PR DESCRIPTION
This pull request adds `toString()` overrides on the `Time` and `TimeStandard` classes that provide a human-readable representation of times rather than the java-default _class-name@memory-hash_ implementation.