### PR TITLE
Add convenience method for re-using existing ValidationContexts

### DIFF
--- a/golem-core/src/golem/util/validation/common.kt
+++ b/golem-core/src/golem/util/validation/common.kt
@@ -89,6 +89,17 @@ class ValidationContext {
             validator.performValidation(this)
     }
 
+    /**
+     * Check declared matrices against any rules that have been added with addValidator, after
+     * running the given callback.
+     *
+     * @param fn A function to execute before validating.
+     */
+    fun validate(fn: ValidationContext.() -> Unit) {
+        fn()
+        validate()
+    }
+
     inline fun <reified T> metadata(key: String, factory: () -> T): T {
         return metadataStorage.getOrPut(key, { factory() as Any }) as T
     }
@@ -144,8 +155,7 @@ fun testMatrix(matrix: Matrix<Double>, name: String) : ValidationContext  {
  */
 fun validate(fn: ValidationContext.() -> Unit) {
     val ctx = ValidationContext()
-    ctx.fn()
-    ctx.validate()
+    ctx.validate(fn)
 }
 
 /**


### PR DESCRIPTION
This PR adds a simple convenience function that I've added as an extension method elsewhere on projects that use golem. It allows one to intuitively re-use a validation context thus:

```kotlin
ctx.validate {
    /* your validation here */
}
```

instead of the more verbose and unintuitive


```kotlin
ctx.apply {
    /* your validation here */
    validate()
}
```
